### PR TITLE
Add local RAG chat MVP skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Python
+.venv/
+__pycache__/
+*.pyc
+
+# Node
+node_modules/
+frontend/node_modules/
+dist/
+
+# Chroma DB
+backend/chroma_db/
+
+# Env
+.env

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,84 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from sentence_transformers import SentenceTransformer
+import chromadb
+import httpx
+import json
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+client = chromadb.PersistentClient(path="backend/chroma_db")
+col = client.get_or_create_collection("kb")
+embedder = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+
+SYSTEM = (
+    "You are a helpful assistant. Use ONLY the context to answer."
+    " If not present, say you don't know from our docs. Cite as [S1]...[S4]."
+)
+
+
+class ChatReq(BaseModel):
+    message: str
+
+
+def prompt_for(q: str, hits):
+    ctx = []
+    cite_map = []
+    for i, (doc, meta) in enumerate(hits, 1):
+        ctx.append(f"[S{i}] {doc}")
+        src = meta.get("source", "")
+        page = meta.get("page")
+        cite_map.append(f"S{i}: {src}{f' p.{page}' if page is not None else ''}")
+    p = (
+        f"{SYSTEM}\n\nCONTEXT:\n"
+        + "\n\n".join(ctx)
+        + f"\n\nUSER: {q}\nASSISTANT:"
+    )
+    return p, cite_map
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.post("/chat")
+async def chat(req: ChatReq):
+    q_emb = embedder.encode([req.message], normalize_embeddings=True).tolist()[0]
+    r = col.query(
+        query_embeddings=[q_emb], n_results=4, include=["documents", "metadatas"]
+    )
+    if not r["documents"] or not r["documents"][0]:
+        return {"text": "I don't know from our docs.", "citations": []}
+    hits = list(zip(r["documents"][0], r["metadatas"][0]))
+    prompt, cites = prompt_for(req.message, hits)
+
+    async with httpx.AsyncClient(timeout=None) as s:
+        stream = s.stream(
+            "POST",
+            "http://localhost:11434/api/generate",
+            json={
+                "model": "phi3.5:3.8b",
+                "prompt": prompt,
+                "stream": True,
+                "options": {"num_ctx": 4096, "num_predict": 256, "temperature": 0.2},
+            },
+        )
+        text = ""
+        async with stream as resp:
+            async for line in resp.aiter_lines():
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                    text += obj.get("response", "")
+                except Exception:
+                    pass
+    return {"text": text.strip(), "citations": cites}

--- a/backend/ingest.py
+++ b/backend/ingest.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from langchain_community.document_loaders import PyPDFLoader, TextLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from sentence_transformers import SentenceTransformer
+import chromadb
+
+DOCS = Path(__file__).resolve().parents[1] / "docs"
+DB_DIR = str(Path(__file__).resolve().parent / "chroma_db")
+
+
+def load_docs():
+    items = []
+    for p in DOCS.rglob("*"):
+        if p.suffix.lower() == ".pdf":
+            items += PyPDFLoader(str(p)).load()
+        elif p.suffix.lower() in {".txt", ".md"}:
+            items += TextLoader(str(p), encoding="utf-8").load()
+    return items
+
+
+def main():
+    raw = load_docs()
+    splitter = RecursiveCharacterTextSplitter(chunk_size=900, chunk_overlap=150)
+    chunks = splitter.split_documents(raw)
+    enc = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+    embs = enc.encode([c.page_content for c in chunks], normalize_embeddings=True)
+
+    client = chromadb.PersistentClient(path=DB_DIR)
+    col = client.get_or_create_collection("kb")
+    col.add(
+        ids=[f"id-{i}" for i in range(len(chunks))],
+        documents=[c.page_content for c in chunks],
+        metadatas=[{
+            "source": (c.metadata.get("source") or c.metadata.get("file_path") or ""),
+            "page": c.metadata.get("page", None)
+        } for c in chunks],
+        embeddings=embs.tolist(),
+    )
+    print(f"Indexed {len(chunks)} chunks.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -1,0 +1,4 @@
+# Sample Document
+
+This project demonstrates a local retrieval-augmented generation system.
+It uses FastAPI for the backend and React for the frontend.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Local RAG Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "local-rag-chat",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+
+export default function App() {
+  const [messages, setMessages] = useState([])
+  const [input, setInput] = useState('')
+
+  const send = async () => {
+    if (!input.trim()) return
+    const user = { role: 'user', text: input }
+    setMessages((m) => [...m, user])
+    setInput('')
+    const res = await fetch('http://localhost:8000/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: user.text }),
+    })
+    const data = await res.json()
+    setMessages((m) => [...m, { role: 'assistant', text: data.text, citations: data.citations }])
+  }
+
+  const clear = () => setMessages([])
+
+  return (
+    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+      <h2>Local RAG Chat</h2>
+      <div style={{ minHeight: '200px', border: '1px solid #ccc', padding: '0.5rem' }}>
+        {messages.map((m, i) => (
+          <div key={i} style={{ marginBottom: '0.5rem' }}>
+            <b>{m.role === 'user' ? 'You' : 'Assistant'}:</b> {m.text}
+            {m.citations && (
+              <div style={{ fontSize: '0.8em', color: '#666' }}>
+                {m.citations.join(' | ')}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <input
+        style={{ width: '80%', padding: '0.5rem', marginTop: '0.5rem' }}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' ? send() : null}
+      />
+      <button onClick={send} style={{ marginLeft: '0.5rem' }}>Send</button>
+      <button onClick={clear} style={{ marginLeft: '0.5rem' }}>Clear</button>
+    </div>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+})


### PR DESCRIPTION
## Summary
- scaffold backend ingestion and chat endpoints for local RAG
- add minimal React/Vite frontend for chatting with citations
- include sample docs and gitignore

## Testing
- `python -m py_compile backend/ingest.py backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bef5135a70832fa85aefd116627e9d