### PR TITLE
feat(frontend): redesign chat layout as AskTod

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Local RAG Chat</title>
+    <title>AskTod</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,68 @@
+.asktod-container {
+  padding: 1rem;
+  font-family: sans-serif;
+}
+
+.chat-layout {
+  display: flex;
+  align-items: flex-start;
+}
+
+.bot-image {
+  width: 200px;
+  height: 200px;
+  margin-right: 1rem;
+  border-radius: 10px;
+  object-fit: cover;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.chat-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.messages {
+  min-height: 200px;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  background: #f9f9f9;
+  margin-bottom: 0.5rem;
+  border-radius: 4px;
+  overflow-y: auto;
+}
+
+.message {
+  margin-bottom: 0.5rem;
+}
+
+.input-area {
+  display: flex;
+  flex-direction: column;
+}
+
+.input-area input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.buttons {
+  margin-top: 0.5rem;
+}
+
+.buttons button {
+  margin-right: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #1976d2;
+  color: #fff;
+  cursor: pointer;
+}
+
+.buttons button:hover {
+  background-color: #115293;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import './App.css'
 
 export default function App() {
   const [messages, setMessages] = useState([])
@@ -21,28 +22,37 @@ export default function App() {
   const clear = () => setMessages([])
 
   return (
-    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
-      <h2>Local RAG Chat</h2>
-      <div style={{ minHeight: '200px', border: '1px solid #ccc', padding: '0.5rem' }}>
-        {messages.map((m, i) => (
-          <div key={i} style={{ marginBottom: '0.5rem' }}>
-            <b>{m.role === 'user' ? 'You' : 'Assistant'}:</b> {m.text}
-            {m.citations && (
-              <div style={{ fontSize: '0.8em', color: '#666' }}>
-                {m.citations.join(' | ')}
+    <div className="asktod-container">
+      <h2>AskTod</h2>
+      <div className="chat-layout">
+        <img src="https://twemoji.maxcdn.com/v/latest/svg/1f916.svg" alt="AskTod bot" className="bot-image" />
+        <div className="chat-area">
+          <div className="messages">
+            {messages.map((m, i) => (
+              <div key={i} className="message">
+                <b>{m.role === 'user' ? 'You' : 'AskTod'}:</b> {m.text}
+                {m.citations && (
+                  <div style={{ fontSize: '0.8em', color: '#666' }}>
+                    {m.citations.join(' | ')}
+                  </div>
+                )}
               </div>
-            )}
+            ))}
           </div>
-        ))}
+          <div className="input-area">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => (e.key === 'Enter' ? send() : null)}
+              placeholder="Type your question here..."
+            />
+            <div className="buttons">
+              <button onClick={send}>Send</button>
+              <button onClick={clear}>Clear</button>
+            </div>
+          </div>
+        </div>
       </div>
-      <input
-        style={{ width: '80%', padding: '0.5rem', marginTop: '0.5rem' }}
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-        onKeyDown={(e) => e.key === 'Enter' ? send() : null}
-      />
-      <button onClick={send} style={{ marginLeft: '0.5rem' }}>Send</button>
-      <button onClick={clear} style={{ marginLeft: '0.5rem' }}>Clear</button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Rebrand page to AskTod with left-aligned bot avatar
- Remove local asktod.png asset and load remote robot image
- Add responsive flex layout with separate message and input areas
- Style interface with professional theme

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a687d80832f9a2f6e89662a3e72