### PR TITLE
Animate Tod with gentle thinking rotation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -75,3 +75,19 @@ body {
 .buttons button:hover {
   background-color: #115293;
 }
+
+@keyframes gentleRotate {
+  0% {
+    transform: rotate(-7deg);
+  }
+  50% {
+    transform: rotate(7deg);
+  }
+  100% {
+    transform: rotate(-7deg);
+  }
+}
+
+.tod-thinking {
+  animation: gentleRotate 1.2s infinite ease-in-out;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,7 +60,11 @@ export default function App() {
     <div className="asktod-container">
       <img src="/asktod.png" alt="AskTod logo" className="asktod-logo" />
       <div className="chat-layout">
-        <img src={botImages[botState]} alt="AskTod bot" className="bot-image"/>
+        <img
+          src={botImages[botState]}
+          alt="AskTod bot"
+          className={`bot-image ${botState === 'thinking' ? 'tod-thinking' : ''}`}
+        />
         <div className="chat-area">
           <div className="messages">
             {messages.map((m, i) => (


### PR DESCRIPTION
## Summary
- Animate Tod's image with a gentle 7° rotation when the bot is thinking
- Add CSS keyframes and class to drive the subtle back-and-forth motion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf577aba44832fa6163888bd1c9ce6