### PR TITLE
Remove extra Tod image from chat UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14,14 +14,13 @@
 
 .bot-image-wrapper {
   position: relative;
-  width: 100px;
-  height: 100px;
+  width: 25%;
   margin-right: 1rem;
 }
 
 .bot-image {
-  width: 25%;
-  height: 25%;
+  width: 100%;
+  height: auto;
   border-radius: 10px;
   object-fit: cover;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -110,11 +110,6 @@ export default function App() {
               </span>
             ))}
         </div>
-        <img
-          src={botImages[botState]}
-          alt="AskTod bot"
-          className={`bot-image ${botState === 'thinking' ? 'tod-thinking' : ''}`}
-        />
         <div className="chat-area">
           <div className="messages">
             {messages.map((m, i) => (


### PR DESCRIPTION
## Summary
- remove duplicate Tod image from chat layout
- adjust image wrapper styling so main bot image fills area

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf5de808ec832fa40d6fd87cf755a3